### PR TITLE
[core] Allow unflattened json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "i18n-checker",
-  "version": "1.1.0",
+  "name": "@linagora/i18n-checker",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1043,15 +1043,6 @@
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1061,6 +1052,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -1609,6 +1609,14 @@
             "spdx-expression-parse": "1.0.4"
           }
         }
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "requires": {
+        "is-buffer": "2.0.3"
       }
     },
     "glob-all": {
@@ -2566,6 +2574,11 @@
           }
         }
       }
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "json-dup-key-validator": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "colors": "1.1.2",
+    "flat": "4.1.0",
     "glob-all": "3.1.0",
     "json-dup-key-validator": "1.0.0",
     "lodash": "4.17.4",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const q = require('q');
 const path = require('path');
 const jade = require('./jade');
+const flatten = require('flat');
 
 function listFilesInDir(dirPath) {
   try {
@@ -13,7 +14,7 @@ function listFilesInDir(dirPath) {
 
 function readJsonFile(filePath) {
   try {
-    return require(filePath) || {};
+    return flatten(require(filePath) || {});
   } catch (err) {
     return {};
   }

--- a/test/rules/valid-json-file/fixture/core/unflattened.json
+++ b/test/rules/valid-json-file/fixture/core/unflattened.json
@@ -1,0 +1,7 @@
+{
+  "key": "value",
+  "nested": {
+    "prop": "nested value"
+  },
+  "other.nested.prop": "other nested value"
+}

--- a/test/rules/valid-json-file/valid-json-file.spec.js
+++ b/test/rules/valid-json-file/valid-json-file.spec.js
@@ -53,4 +53,16 @@ describe('The valid-json-file rule', function() {
       done();
     });
   });
+
+  it('should detect valid JSON unflattened file', function(done) {
+    options.verifyOptions.locales = ['unflattened'];
+    options.verifyOptions.defaultLocale = 'unflattened';
+
+    lib(options, (err, resp) => {
+      expect(err).to.not.exist;
+      // Expect to be valid
+      expect(resp).to.deep.equal([]);
+      done();
+    });
+  });
 });

--- a/test/utils/index/fixture/en.json
+++ b/test/utils/index/fixture/en.json
@@ -1,0 +1,7 @@
+{
+  "core": "core",
+  "nested": {
+    "prop": "nestedProp"
+  },
+  "other.nested": "otherNestedProp"
+}

--- a/test/utils/index/index.js
+++ b/test/utils/index/index.js
@@ -1,0 +1,15 @@
+const expect = require('chai').expect;
+const path = require('path');
+const lib = require('../../../src/utils');
+
+describe('The utils/index module', function() {
+  it('should extract all i18n keys in the json file and flatten keys', function() {
+    const keys = lib.getKeysInJsonFile(path.join(__dirname, 'fixture/en.json'));
+
+    expect(keys).to.deep.equal([
+      'core',
+      'nested.prop',
+      'other.nested'
+    ]);
+  });
+});


### PR DESCRIPTION
i18n-checker allow to compare only flat files : 
```JSON
{
    "foo.bar": "value"
}
```

This pull request allow unflattened files : 
```JSON
{
    "foo": {
        "bar": "value"
    }
}
```